### PR TITLE
remove comment that stops query execution(deleting lists)

### DIFF
--- a/listView.php
+++ b/listView.php
@@ -96,7 +96,7 @@ if (!empty($_POST['old_ID']) && !empty($_POST['new_name'])){
 if (!empty($_POST['Delete_listID'])){
 	//If the user submitted a new delete list request we run this code - takes the list's id as input
 	$query = " 
-            DELETE FROM taskList    // deleting list from the task list 
+            DELETE FROM taskList    
             WHERE listID = :Delete_listID "; 
         $query_params = array (
           ':Delete_listID' => $_POST['Delete_listID'] //Delete list


### PR DESCRIPTION
there was a comment within the query that was stopping it from being executed fully - it has now been removed, and lists get deleted