### PR TITLE
Filtering tasks within Lists

### DIFF
--- a/CSS/BoardView-Body.css
+++ b/CSS/BoardView-Body.css
@@ -17,6 +17,10 @@
     max-width: 500px;
 }
 
+.card:hover {
+    cursor: pointer;
+}
+
 .card-header .btn {
     visibility: hidden;
 }

--- a/CSS/BoardView-Body.css
+++ b/CSS/BoardView-Body.css
@@ -23,7 +23,6 @@
 
 .card-header:hover {
     background-color: #669999;
-    cursor: pointer;
 }
 
 .card-header:hover .btn {
@@ -35,6 +34,10 @@
 .card-Title button {
     float: right;
     padding: 0%;
+}
+
+.card-Title:hover {
+    cursor: pointer;
 }
 
 .list-group-item:hover {

--- a/CSS/BoardView-Body.css
+++ b/CSS/BoardView-Body.css
@@ -17,16 +17,13 @@
     max-width: 500px;
 }
 
-.card:hover {
-    cursor: pointer;
-}
-
 .card-header .btn {
     visibility: hidden;
 }
 
 .card-header:hover {
     background-color: #669999;
+    cursor: pointer;
 }
 
 .card-header:hover .btn {

--- a/filterList.php
+++ b/filterList.php
@@ -1,0 +1,74 @@
+<?php
+session_start();
+?>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+
+<!-- This is the code for the page to filter tasks within a list -->
+
+<?php
+require('conn.php');
+$stmt = $db->prepare('SELECT listTitle FROM taskList WHERE `listID`= ? ');
+$stmt->execute(array($_GET['id']));       
+$list = $stmt->fetch();
+// display list name so user can confirm the list they're editing
+echo "Apply filters for ".$list['listTitle']." list <br>";
+
+if(!empty($_POST['filter'])) {
+
+    // get user inputs for properties
+    $by_name = $_POST['filt_name'];
+    $by_effort = $_POST['filt_effort'];
+    $by_work = $_POST['filt_work'];
+    $by_date = strtotime($_POST['filt_date']);
+    $id = $_GET['id'];
+
+    // build initial query
+    $query = "SELECT * FROM task WHERE `tl.listID` = ".$id."";
+
+    // extend query based on user input filters
+    if(! empty($by_name)) {
+        $query .= " AND `taskTitle`='".$by_name."' ";
+    }
+    if(! empty($by_effort)) {
+      $query .= " AND `importance`='".$by_effort."' ";
+    }
+    if(! empty($by_work)) {
+      $query .= " AND `typeOfWork`='".$by_work."' ";
+    }
+    if(! empty($by_date)) {
+        $query .= " AND `dueDate`='".$by_date."' ";
+    }
+
+    $stmt = $db->prepare($query);
+    $stmt->execute();  
+        
+    if($stmt->rowCount() > 0) {
+        $filtered_tasks = $stmt->fetchAll();
+        foreach($filtered_tasks as $task){
+            echo "<br>Title:".$task['taskTitle']."<br>";
+            echo "Description: ".$task['description']."<br>";
+    
+        }
+    } //dealing with no result outputs(edge cases tested)
+    else {
+    echo "<br> No results found - please try again. <br>";
+    }
+
+}
+?>
+
+<!-- Form to take in user inputs -->
+<form action="filterList.php?id=<?php echo $_GET['id']; ?>" method="POST"> 
+
+    <br>
+    <input type="text" name="filt_name" value="" class="form-control" placeholder="Task Title"/>
+    <br>
+    <input type="number" name="filt_effort" value="" class="form-control" placeholder="Importance"/>
+    <br>
+    <input type="text" name="filt_work" value="" class="form-control" placeholder="Type of Work"/>
+    <br>
+    <input type="datetime-local" name="filt_date" value="unchanged" class="form-control" placeholder="Due Date"/>
+    <br>
+    <input type="submit" class="btn btn-warning" name="filter" value="Filter List">
+
+</form>

--- a/listView.php
+++ b/listView.php
@@ -161,7 +161,7 @@ foreach ($lists as $list){
 	<div class='col-xs-3'>
 	<div class='card'>
 	<div class='card-header'>
-    <div class ='card-Title'>
+    <div class ='card-Title' onclick='dynamicModal(".$list['listID'].")' data-toggle='modal' data-target='#filterList'>
       ".$list['listTitle']."  
     </div>
   </div>
@@ -279,6 +279,24 @@ echo "</div>";
   </div>
 </div>
 
+<!-- Modal to filter lists - upon clicking this, the user can filter the tasks in their lists based on properties such as task title, importance, type of work, and due date -->
+<!-- The tasks(title and description) will be displayed within the modal itself, this can change in later iterations-->
+<div class="modal fade" id="filterList" tabindex="-1" aria-labelledby="filterList" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content" style="width:578px;">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">Filter View</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body" >
+        <iframe sandbox="allow-top-navigation allow-scripts allow-forms" class="embed-responsive-item" id="filterListFrame" style="border:0; width:558px; height:700px;" src="listView.php"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!--Below we have the code for our "modal" which pops up when the user clicks a task. The modal outputs all the details of the task-->
 <div class="modal fade" id="viewTask" tabindex="-1" aria-labelledby="viewTask" aria-hidden="true">
   <div class="modal-dialog">
@@ -355,10 +373,11 @@ echo "</div>";
 
 <script>
 
-// function to refresh the modal page for task details
+// function to refresh the modal page for task details and filtering task
 function dynamicModal(str)
 {
 $("#viewTaskFrame").attr("src", "https://mansci-db.uwaterloo.ca/~wmmeyer/viewTask.php?id="+str);
+$("#filterListFrame").attr("src", "https://mansci-db.uwaterloo.ca/~wmmeyer/dev_gaurav/filterList.php?id="+str);
 }
 </script>
 

--- a/listView.php
+++ b/listView.php
@@ -157,6 +157,7 @@ $stmt = $db->prepare('SELECT * FROM taskList WHERE boardID = ? ORDER BY `listID`
 echo "<div class='row'>";
 foreach ($lists as $list){
   //This code is run FOR EACH list that exists.
+  //Each list name can be clicked to access the filtering functionality(UX needs to be improved a little)
 	echo "
 	<div class='col-xs-3'>
 	<div class='card'>
@@ -377,7 +378,7 @@ echo "</div>";
 function dynamicModal(str)
 {
 $("#viewTaskFrame").attr("src", "https://mansci-db.uwaterloo.ca/~wmmeyer/viewTask.php?id="+str);
-$("#filterListFrame").attr("src", "https://mansci-db.uwaterloo.ca/~wmmeyer/dev_gaurav/filterList.php?id="+str);
+$("#filterListFrame").attr("src", "https://mansci-db.uwaterloo.ca/~wmmeyer/dev_gaurav/filterList.php?id="+str); //this link will need to change once deployed
 }
 </script>
 


### PR DESCRIPTION
This functionality allows users to filter tasks within their lists - this will be useful when users want to search for tasks from a large/varied pool of them in a list.

The feature can be accessed by clicking the list name within the board - I'm looking to improve the UX for this.
A pop-up modal allows the user to enter their inputs.

The functionality has been tested on various cases for inputs, such as:
- Empty/Null Inputs
- Single/multi-property inputs
- Wrong inputs(no results obtained)

The properties by which the users can filter their tasks are:
- Task title
- Importance
- Type of Work
- Due Date
All these get filtered with respect to their exact values - in the future, we can look into the user specifying how they would like to filter (e.g. importance < 2 instead of exactly = 2).

As of now, the filtered tasks(title and description) get displayed on a separate page, which has been implemented as a pop-up modal.