### PR TITLE
Share boards with users taking the same course

### DIFF
--- a/selectBoard.php
+++ b/selectBoard.php
@@ -7,6 +7,7 @@ if(empty($_SESSION['user']))
         die("Redirecting to index.html"); 
     } 
 require("conn.php");
+
 //If we have a deleteID request we must delete the board by ID
 if (!empty($_POST['deleteID'])){
 $stmt = $db->prepare('DELETE FROM board WHERE boardID=?');
@@ -14,6 +15,8 @@ $stmt = $db->prepare('DELETE FROM board WHERE boardID=?');
             $deleteboard = $stmt->fetch();
 
 }
+
+// sharing an existing board
 if (!empty($_POST['boardIDshare'])){
 $stmt = $db->prepare('DELETE FROM board WHERE boardID=?');
             $stmt->execute(array($_POST['deleteID']));       
@@ -38,6 +41,7 @@ $stmt = $db->prepare('DELETE FROM board WHERE boardID=?');
        	$result = $stmt->execute($query_params); 
 }
 
+// creating a new board
 if (!empty($_POST['boardName'])){
 $query = " 
             INSERT INTO board ( 
@@ -181,6 +185,7 @@ foreach ($shares as $share){
             </select>
             <br>
             <select name="permission" class="form-control" required>
+            <option value="" disabled selected>Permission</option>
             <option value="edit">Edit</option>
             <option value="view">View</option>
             </select>

--- a/selectBoard.php
+++ b/selectBoard.php
@@ -117,11 +117,13 @@ $query = "
         </div>
 </div>
 <div class="editfeatures">
+
   <!-- button to create board -->
   <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#createBoard">
   Create Board
   </button>
 </div>
+
 <div class="row">
 <?php
 $stmt = $db->prepare('SELECT * FROM share WHERE `u.WATIAM` = ? ORDER BY `b.boardID` DESC');
@@ -145,6 +147,9 @@ foreach ($shares as $share){
 		   	?>
 		   	<button type="button" class="btn btn-info" data-toggle="modal" data-target="#shareBoard">
 		    Share
+		    </button>
+        <button type="button" class="btn btn-info" onclick="dynamicModal(<?php echo $board['boardID']; ?>)" data-toggle="modal" data-target="#shareBoardCourse">
+		    Share using course
 		    </button>
 		   	<form action = "selectBoard.php" method = "POST" style="display:inline-block;"> 
 		      <input type="hidden" name="deleteID" value="<?php echo $board['boardID']; ?>">
@@ -198,6 +203,23 @@ foreach ($shares as $share){
     </div>
   </div>
 </div>
+
+<div class="modal fade" id="shareBoardCourse" tabindex="-1" aria-labelledby="shareBoardCourse" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">Share Board using Course</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <iframe sandbox="allow-top-navigation allow-scripts allow-forms" class="embed-responsive-item" id="shareBoardFrame" style="border:0; width:450px; height:700px;" src="shareBoardCourse.php"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+
 <?php           
 }
 ?>
@@ -223,6 +245,12 @@ foreach ($shares as $share){
   </div>
 </div>
 
+<script>
+function dynamicModal(str)
+{
+$("#shareBoardFrame").attr("src", "https://mansci-db.uwaterloo.ca/~wmmeyer/dev_gaurav/shareBoardCourse.php?id="+str); //this link will need to change once deployed
+}
+</script>
 
 <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>

--- a/shareBoardCourse.php
+++ b/shareBoardCourse.php
@@ -1,0 +1,70 @@
+<?php
+session_start();
+
+// if(empty($_SESSION['user'])) 
+//     { 
+//         header("Location: index.html"); 
+//         die("Redirecting to index.html"); 
+//     } 
+
+require('conn.php');
+?>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+
+<?php
+
+// echo $_GET['id'];
+if(!empty($_POST['share'])) {
+
+    // echo $_POST['course'];
+    
+    $stmt = $db->prepare('SELECT DISTINCT(`u.WATIAM`) from board WHERE boardID IN (SELECT boardID from `taskList` WHERE `listID` IN (SELECT `tl.listID` FROM `task` WHERE `c.courseID` = ?))');     
+    $stmt->execute(array($_POST['course']));  
+    $users = $stmt->fetchAll();
+    ?>
+
+    <form action="selectBoard.php" class="edit-ListName" method="POST">
+    <?php
+    echo "<select name='user' class='form-control' required>";
+    echo "<option value='' disabled selected>Select User</option>";
+    foreach($users as $user):
+        if($user['u.WATIAM']!==$_SESSION['user'])
+        {
+            // echo "<br>";
+            // echo "working";
+            echo "<option value='".$user['u.WATIAM']."'>".$user['u.WATIAM']."</option>";
+            // echo "<br>";
+        } // include edge case for no one sharing a course
+    endforeach;
+    echo "</select>";
+    ?>
+    <br>
+    <select name="permission" class="form-control" required>
+            <option value="" disabled selected>Permission</option>
+            <option value="edit">Edit</option>
+            <option value="view">View</option>
+    </select>
+    <br>
+    <input type="hidden" name="boardIDshare" id="boardIDshare" value="<?php echo $_GET['id']; ?>">
+    <button class="btn btn-lg btn-primary btn-block" type="submit" name="shareSubmit" value="shareSubmit">Share</Title></button>
+    </form>
+
+    <br>
+    <br>
+<?php } ?>
+    
+<form action="shareBoardCourse.php?id=<?php echo $_GET['id']; ?>" method="POST" class="edit-ListName" >
+        <?php
+            $stmt = $db->prepare('SELECT courseID, courseTitle FROM `course` WHERE courseID IN (SELECT DISTINCT(task.`c.courseID`) FROM `task` WHERE task.`tl.listID` IN (SELECT l.listID FROM `board` b NATURAL JOIN `taskList` l WHERE b.boardID = ? ))');     
+            $stmt->execute(array($_GET['id']));  
+            $courses = $stmt->fetchAll();
+        	?>
+            <select name="course" class="form-control" required>
+            <option value="" disabled selected>Select Course</option>
+            <?php foreach($courses as $course): ?>
+              <option value = "<?php echo $course['courseID']; ?>"> <?php echo $course['courseTitle']; ?> </option>
+            <?php endforeach; ?>
+            </select>
+            <br>
+            <input type="submit" class="btn btn-warning" name="share" value="Find Students">   
+</form>


### PR DESCRIPTION
This PR adds functionality that allows a user to look for users with whom they can share their board, based on the courses that they are taking.

A new file(`shareBoardCourse.php`) handles all the operations related to this - which gets displayed as a pop-up modal on the Board Selection page when the 'Share using Course' button is clicked.

The form takes the course name as input from a dropdown, which upon submitting produces another form, asking the user to choose someone to share it with, along with the permission.

Unit Tests:

- Board owner's name was also being displayed in the options for sharing - fixed using a simple string comparison
- Only Course ID's were getting displayed in the dropdown - fixed by extending the query to include Course Titles

***Issue***: As the 'Share' button is clicked, the modal refreshes, and displays the homepage within it, instead of closing it. I was hoping someone who has encountered something similar would help me with this.

Other than the issue described above, everything looks good to me.